### PR TITLE
added support for simplejson and ujson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template 
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -20,7 +20,10 @@ unpack_double = Struct('=d').unpack
 from utils import *
 
 FRAMEWORKS = [
-        ('json',''),('msgpack',''),
+        ('json',''),
+        ('sjson',''),
+        ('ujson',''),
+        ('msgpack',''),
         ('protobuf','py'), ('protobuf','pyext'),
         ('thrift','py'), ('thrift','pyext'),
         ('pycapnp',''),
@@ -462,6 +465,38 @@ def build_benchmark(message, framework, implementation, target, **benchargs):
         benchargs['serialize_func'] = build_json_serializer()
     
         build_dsrz = build_json_deserializer
+
+
+    elif framework == 'sjson':
+
+        # Validate that framework can be loaded
+        if not is_sjson_available():
+            raise RuntimeError("required framework can not be loaded !")
+
+        # load schema
+        from schema import get_sjsonstuff
+        benchargs['schema'] = get_sjsonstuff()
+
+        # add serializer
+        benchargs['serialize_func'] = build_sjson_serializer()
+
+        build_dsrz = build_sjson_deserializer
+
+
+    elif framework == 'ujson':
+
+        # Validate that framework can be loaded
+        if not is_ujson_available():
+            raise RuntimeError("required framework can not be loaded !")
+
+        # load schema
+        from schema import get_ujsonstuff
+        benchargs['schema'] = get_ujsonstuff()
+
+        # add serializer
+        benchargs['serialize_func'] = build_ujson_serializer()
+
+        build_dsrz = build_ujson_deserializer
         
     elif framework == 'msgpack':
 

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -18,6 +18,8 @@ import utils
 
 FRAMEWORKS = [
     ('json', utils.is_json_available),
+    ('sjson', utils.is_sjson_available),
+    ('ujson', utils.is_ujson_available),
     ('msgpack', utils.is_msgpack_available),
     ('protobuf/py', utils.is_protobuf_available),
     ('thrift/py', utils.is_thrift_available),

--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -1,5 +1,7 @@
 #  -*- coding: utf-8 -*-
 
+import importlib
+from functools import partial
 from os.path import abspath, dirname, join
 
 __all__ = [
@@ -200,13 +202,13 @@ class CapNpStructProxy(StructProxy):
 
 
 # provide json version of StuffToTest schema
-def get_jsonstuff():
+def get_jsonstuff_internal(module_name):
     "return json equivalent for StuffToTest schema"
 
-    import json
+    module = importlib.import_module(module_name)
 
     # contruct schema
-    schema = SchemaContainer('json', json.__version__)
+    schema = SchemaContainer('module_name', module.__version__)
 
     context = {}
 
@@ -225,6 +227,10 @@ def get_jsonstuff():
         context[message] = structProxy
 
     return schema
+
+get_jsonstuff = partial(get_jsonstuff_internal, 'json')
+get_sjsonstuff = partial(get_jsonstuff_internal, 'simplejson')
+get_ujsonstuff = partial(get_jsonstuff_internal, 'ujson')
 
 # provide msgpack version of StuffToTest schema
 def get_msgpackstuff():

--- a/utils.py
+++ b/utils.py
@@ -165,6 +165,24 @@ def is_json_available(ignored=False):
     except:
         return False
 
+def is_sjson_available(ignored=False):
+    "return True if simplejson can be imported"
+
+    try:
+        import simplejson
+        return True
+    except:
+        return False
+
+def is_ujson_available(ignored=False):
+    "return True if ujson can be imported"
+
+    try:
+        import ujson
+        return True
+    except:
+        return False
+
 def build_json_serializer():
     "return json.dumps callable"
 
@@ -172,10 +190,38 @@ def build_json_serializer():
 
     return dumps
 
+def build_sjson_serializer():
+    "return simplejson.dumps callable"
+
+    from simplejson import dumps
+
+    return dumps
+
+def build_ujson_serializer():
+    "return ujson.dumps callable"
+
+    from ujson import dumps
+
+    return dumps
+
 def build_json_deserializer(Msg, ignored=False):
     "return json.loads callable"
 
     from json import loads
+
+    return loads
+
+def build_sjson_deserializer(Msg, ignored=False):
+    "return json.loads callable"
+
+    from simplejson import loads
+
+    return loads
+
+def build_ujson_deserializer(Msg, ignored=False):
+    "return json.loads callable"
+
+    from ujson import loads
 
     return loads
 


### PR DESCRIPTION
Added support for simplejson and ujson.

Sometimes you must use json (ex: talking to the browser or want a human readable format).

Then if you want to squeeze every bit of performance there's the drop-in replacement simplejson and also ujson (slight less compatible).

ps: importlib requires 2.7+ (which is a safe assumption these days) but there's also a backport in pypi
